### PR TITLE
Make sure we parse all the output, so we do not fall behind.

### DIFF
--- a/osx-location.el
+++ b/osx-location.el
@@ -101,7 +101,7 @@ the same directory as this library."
   "Look for and respond to process output which indicates a location change."
   (save-excursion
     (goto-char osx-location-last-match-end-pos)
-    (when (re-search-forward
+    (while (re-search-forward
            "latitude,lon?gitude : \\(-?[0-9]+\\.[0-9]+\\), \\(-?[0-9]+\\.[0-9]+\\)"
            nil t)
       (setq osx-location-latitude (string-to-number (match-string 1))


### PR DESCRIPTION
This is a quick fix to ensure that the parsing does not fall behind.  In my case the location was really far behind the actual location because the parse code was not parsing the most recent entries, but was far behind.   

It might be that my usage of sleeping and waking up my laptop a lot might have something todo with it, but even so, there is no guarantee that the process-filter is called per line.

This fix is a hack[?], it will generate events for all the position changes that have occurred, a better fix might be to just parse the last location line.  However this depends on the use case and is a bit more involved. 
